### PR TITLE
fix-productos-stock Problema al listar almacenes

### DIFF
--- a/packages/panel/src/pages/productos/ProductoStockModal.tsx
+++ b/packages/panel/src/pages/productos/ProductoStockModal.tsx
@@ -98,7 +98,14 @@ export default function ProductoStockModal({
     }
   }, [stock]);
 
-  // Reset state when modal closes
+  // Cargar almacenes cada vez que se abre el modal
+  useEffect(() => {
+    if (open) {
+      listarAlmacenes();
+    }
+  }, [open, listarAlmacenes]);
+
+  // Reset state cuando se cierra el modal, pero sin borrar almacenes globales
   useEffect(() => {
     if (!open) {
       setSelectedAlmacen("");
@@ -108,7 +115,7 @@ export default function ProductoStockModal({
         transito: 0,
         rma: 0,
       });
-      useAlmacenesStore.setState({ almacenes: [] });
+      // No borrar almacenes aquí
     }
   }, [open]);
 


### PR DESCRIPTION
Descripcion del Error: Al inspeccionar el Stock de un almacen de un producto, muestra todo bien, al intentar hacer de nuevo la misma accion con el mismo producto o con otro, NO carga la lista de Almacenes para verificar el Stock.

Solucion: No se deberia borrar la lista de almacenes globalmente, especialmente si en la sección de productos los almacenes no cambian frecuentemente. Es mejor simplemente recargar la lista cada vez que se abre el modal, asegurando que siempre esté actualizada y evitando problemas de estado global. Así, cada vez que se abra el modal, se recargan los almacenes, pero nunca se borran globalmente.
