### PR TITLE
Actualizar los precios segun el tipo de cambio dinámicamente

### DIFF
--- a/packages/backend/src/routes/dashboard.routes.ts
+++ b/packages/backend/src/routes/dashboard.routes.ts
@@ -20,6 +20,7 @@ DashboardRouter.get("/", async (req: Request, res: Response) => {
 
   const ordenesRepository = AppDataSource.getRepository(Orden);
 
+  // Solo se consideran ventas con estatus Confirmado o Entregado para el dashboard
   const ventasMensuales = await ordenesRepository
     .createQueryBuilder("orden")
     .leftJoin("orden.vendedor", "vendedor")
@@ -29,16 +30,20 @@ DashboardRouter.get("/", async (req: Request, res: Response) => {
     .andWhere("orden.tipo IN (:...tipos)", {
       tipos: [TipoOrden.venta, TipoOrden.credito],
     })
+    // Filtrar solo órdenes con estatus Confirmado o Entregado
+    .andWhere("orden.estatus IN (:...estatus)", { estatus: ["Confirmado", "Entregado"] })
     .andWhere("orden.fechaCreado BETWEEN :start AND :end", {
       start: monthStart,
       end: monthEnd,
     })
     .getMany();
 
+  // Sumar el total de ventas del mes solo con las órdenes filtradas
   const totalVentasMes = ventasMensuales.reduce(
     (acc, orden) => acc + orden.total,
     0
   );
+  // Calcular el promedio de venta solo con las órdenes filtradas
   const promedioVenta =
     ventasMensuales.length > 0 ? totalVentasMes / ventasMensuales.length : 0;
 

--- a/packages/backend/src/routes/ordenes.routes.ts
+++ b/packages/backend/src/routes/ordenes.routes.ts
@@ -798,12 +798,9 @@ OrdenesRouter.put(
       if (!updatedOrden) {
         return res.status(404).json({ error: "Orden no encontrada" });
       }
-      // Solo crear la transacción contable (registro en contabilidad) cuando la orden
-      // sea de tipo venta o crédito y su estatus pase a 'Confirmado'.
-      // Esto evita que se registre contablemente una orden solo aprobada.
       if (
-        [TipoOrden.credito, TipoOrden.venta].includes(updatedOrden.tipo) &&
-        updatedOrden.estatus === EstatusOrden.confirmado
+          updatedOrden.tipo === TipoOrden.credito &&
+          updatedOrden.estatus === EstatusOrden.confirmado
       ) {
         // Insertar transacción de tipo factura
         const transaccion = new Transaccion();

--- a/packages/backend/src/routes/ordenes.routes.ts
+++ b/packages/backend/src/routes/ordenes.routes.ts
@@ -523,6 +523,16 @@ OrdenesRouter.put(
       if (!before) {
         return res.status(404).json({ error: "Orden no encontrada" });
       }
+      // Validación para evitar convertir cotización rechazada en orden
+      if (
+        before.tipo === TipoOrden.cotizacion &&
+        before.estatus === EstatusOrden.rechazado
+      ) {
+        // Si la orden es cotización y está rechazada, no permitir conversión
+        return res.status(400).json({
+          error: "No se puede convertir una cotización rechazada en orden."
+        });
+      }
       await repo.update(ordenId, { tipo: TipoOrden.venta as TipoOrden });
       res.status(200).json({
         message: `Cotización #${before.serial} convertida en orden`,

--- a/packages/backend/src/routes/ordenes.routes.ts
+++ b/packages/backend/src/routes/ordenes.routes.ts
@@ -798,9 +798,12 @@ OrdenesRouter.put(
       if (!updatedOrden) {
         return res.status(404).json({ error: "Orden no encontrada" });
       }
+      // Solo crear la transacción contable (registro en contabilidad) cuando la orden
+      // sea de tipo venta o crédito y su estatus pase a 'Confirmado'.
+      // Esto evita que se registre contablemente una orden solo aprobada.
       if (
-          updatedOrden.tipo === TipoOrden.credito &&
-          updatedOrden.estatus === EstatusOrden.confirmado
+        [TipoOrden.credito, TipoOrden.venta].includes(updatedOrden.tipo) &&
+        updatedOrden.estatus === EstatusOrden.confirmado
       ) {
         // Insertar transacción de tipo factura
         const transaccion = new Transaccion();

--- a/packages/backend/src/routes/personas.routes.ts
+++ b/packages/backend/src/routes/personas.routes.ts
@@ -91,6 +91,8 @@ PersonasRouter.post(
       newPersona.nif = persona.nif;
       persona.empresa && (newPersona.empresa = persona.empresa);
       persona.telefono && (newPersona.telefono = persona.telefono);
+      // Guardar las notas del cliente si existen
+      persona.notas && (newPersona.notas = persona.notas);
       const savedPersona = await AppDataSource.getRepository(Persona).save(
         newPersona
       );

--- a/packages/panel/src/components/ui/alert-dialog.tsx
+++ b/packages/panel/src/components/ui/alert-dialog.tsx
@@ -1,14 +1,15 @@
-import * as React from "react"
-import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+import * as React from "react";
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog";
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils";
+// Importa buttonVariants desde el nuevo archivo separado para evitar conflictos con Fast Refresh/Hot Reload.
+import { buttonVariants } from "@/components/ui/button-variants";
 
-const AlertDialog = AlertDialogPrimitive.Root
+const AlertDialog = AlertDialogPrimitive.Root;
 
-const AlertDialogTrigger = AlertDialogPrimitive.Trigger
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
 
-const AlertDialogPortal = AlertDialogPrimitive.Portal
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
 
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
@@ -22,8 +23,8 @@ const AlertDialogOverlay = React.forwardRef<
     {...props}
     ref={ref}
   />
-))
-AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
@@ -40,8 +41,8 @@ const AlertDialogContent = React.forwardRef<
       {...props}
     />
   </AlertDialogPortal>
-))
-AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 const AlertDialogHeader = ({
   className,
@@ -54,8 +55,8 @@ const AlertDialogHeader = ({
     )}
     {...props}
   />
-)
-AlertDialogHeader.displayName = "AlertDialogHeader"
+);
+AlertDialogHeader.displayName = "AlertDialogHeader";
 
 const AlertDialogFooter = ({
   className,
@@ -68,8 +69,8 @@ const AlertDialogFooter = ({
     )}
     {...props}
   />
-)
-AlertDialogFooter.displayName = "AlertDialogFooter"
+);
+AlertDialogFooter.displayName = "AlertDialogFooter";
 
 const AlertDialogTitle = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Title>,
@@ -80,8 +81,8 @@ const AlertDialogTitle = React.forwardRef<
     className={cn("text-lg font-semibold", className)}
     {...props}
   />
-))
-AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
 
 const AlertDialogDescription = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Description>,
@@ -92,9 +93,9 @@ const AlertDialogDescription = React.forwardRef<
     className={cn("text-sm text-muted-foreground", className)}
     {...props}
   />
-))
+));
 AlertDialogDescription.displayName =
-  AlertDialogPrimitive.Description.displayName
+  AlertDialogPrimitive.Description.displayName;
 
 const AlertDialogAction = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Action>,
@@ -105,8 +106,8 @@ const AlertDialogAction = React.forwardRef<
     className={cn(buttonVariants(), className)}
     {...props}
   />
-))
-AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
 
 const AlertDialogCancel = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
@@ -121,8 +122,8 @@ const AlertDialogCancel = React.forwardRef<
     )}
     {...props}
   />
-))
-AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
 
 export {
   AlertDialog,
@@ -136,4 +137,4 @@ export {
   AlertDialogDescription,
   AlertDialogAction,
   AlertDialogCancel,
-}
+};

--- a/packages/panel/src/components/ui/button-variants.ts
+++ b/packages/panel/src/components/ui/button-variants.ts
@@ -1,0 +1,36 @@
+import { cva } from "class-variance-authority";
+
+// Definición de variantes y tamaños para los botones de la UI.
+// Se separa en este archivo para evitar conflictos con Fast Refresh/Hot Reload en React.
+// Así, el archivo button.tsx solo exporta componentes, lo que mejora la experiencia de desarrollo.
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+);
+
+export { buttonVariants };

--- a/packages/panel/src/components/ui/button.tsx
+++ b/packages/panel/src/components/ui/button.tsx
@@ -1,56 +1,33 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "./button-variants"; // Importa variantes desde archivo separado
 
-const buttonVariants = cva(
-  "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
-  {
-    variants: {
-      variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
-        secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
-      },
-      size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
-      },
-    },
-    defaultVariants: {
-      variant: "default",
-      size: "default",
-    },
-  }
-)
+// Justificación:
+// Se movió la definición de buttonVariants a button-variants.ts para evitar advertencias y problemas con Fast Refresh/Hot Reload.
+// React recomienda que los archivos de componentes solo exporten componentes para que el estado y la recarga en caliente funcionen correctamente.
+// Así, este archivo solo exporta el componente Button.
 
 export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
-  asChild?: boolean
+  asChild?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    const Comp = asChild ? Slot : "button";
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
         {...props}
       />
-    )
+    );
   }
-)
-Button.displayName = "Button"
+);
+Button.displayName = "Button";
 
-export { Button, buttonVariants }
+export { Button };

--- a/packages/panel/src/components/ui/calendar.tsx
+++ b/packages/panel/src/components/ui/calendar.tsx
@@ -3,7 +3,8 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import { DayPicker } from "react-day-picker";
 
 import { cn } from "@/lib/utils";
-import { buttonVariants } from "@/components/ui/button";
+// Importa buttonVariants desde el nuevo archivo separado para evitar conflictos con Fast Refresh/Hot Reload.
+import { buttonVariants } from "@/components/ui/button-variants";
 
 export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 

--- a/packages/panel/src/pages/balance/BalancePage.tsx
+++ b/packages/panel/src/pages/balance/BalancePage.tsx
@@ -43,6 +43,7 @@ export default function TransactionPage() {
     limit,
     setPage,
     setLimit,
+    reset, // Método para limpiar el estado global del store de transacciones
   } = useTransaccionesStore();
 
   useEffect(() => {
@@ -52,6 +53,14 @@ export default function TransactionPage() {
       setPersona(null);
     };
   }, [listarTransacciones, persona, limit, page]);
+
+  // Limpiar el cliente seleccionado y el store de transacciones al desmontar la página de Balance
+  useEffect(() => {
+    return () => {
+      setPersona(null); // Limpia el cliente seleccionado
+      reset(); // Limpia el estado global del store (balance, pagos, reembolsos, transacciones, etc.)
+    };
+  }, [reset]);
 
   const [runTour, setRunTour] = useState(false);
 

--- a/packages/panel/src/pages/dashboard/DashboardPage.tsx
+++ b/packages/panel/src/pages/dashboard/DashboardPage.tsx
@@ -137,6 +137,16 @@ const DashboardPage: React.FC = () => {
     fetchDeudores();
   }, [fetchDashboardData, fetchChartsData, fetchDeudores]);
 
+  // =============================
+  // Modificación: Cálculo del total general de deuda
+  // Se suma el balance de todos los clientes en el array deudores,
+  // que es la misma información mostrada en la Lista de Deudores.
+  // =============================
+  const totalGeneralDeuda = deudores.reduce(
+    (acc, d) => acc + (d.balance || 0),
+    0
+  );
+
   if (isLoading) {
     return (
       <div className="flex justify-center items-center min-h-[400px]">
@@ -169,6 +179,18 @@ const DashboardPage: React.FC = () => {
           })}
           icon={BarChart2}
           className="bg-amber-500/70 dark:bg-amber-400/70"
+        />
+      </div>
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+        {/* =============================
+            Modificación: Nuevo MetricCard para mostrar el total general de deuda de los clientes
+            usando la suma de los balances de los deudores
+         ============================= */}
+        <MetricCard
+          title="Total General de Deuda de Clientes"
+          value={currencyFormat({ value: totalGeneralDeuda })}
+          icon={AlertCircle}
+          className="bg-rose-500/70 dark:bg-rose-400/70"
         />
       </div>
 

--- a/packages/panel/src/pages/ordenes/OrdenForm.tsx
+++ b/packages/panel/src/pages/ordenes/OrdenForm.tsx
@@ -449,6 +449,7 @@ export default function OrdenForm({
                         if (value === TipoOrden.reposicion) {
                           setValue("cliente", null);
                           setValue("proveedor", null);
+                          setValue("tipoCambio", TipoCambio.usd); // Forzar USD cuando es reposición
                         }
                       }}
                       disabled={!!orden}

--- a/packages/panel/src/pages/ordenes/OrdenForm.tsx
+++ b/packages/panel/src/pages/ordenes/OrdenForm.tsx
@@ -620,7 +620,10 @@ export default function OrdenForm({
                                   //   ];
 
                                   // aplicar precio por tipo de cliente
-                                  if (
+                                  // Si es reposición, usar el costo como precio
+                                  if (tipo === TipoOrden.reposicion) {
+                                    item.precio = p.costo || 0;
+                                  } else if (
                                     cliente?.tipoCliente ===
                                     TipoCliente.mayorista
                                   ) {

--- a/packages/panel/src/pages/ordenes/OrdenPreview.tsx
+++ b/packages/panel/src/pages/ordenes/OrdenPreview.tsx
@@ -147,11 +147,12 @@ export const OrdenPreview = ({
                           </p>
                         )}
 
-                        {item.garantia && (
+                        {/* Ocultando la garantía, pero dejando el código comentado para referencia futura */}
+                        {/* {item.garantia && (
                           <p className="text-xs italic text-gray-500 mt-1">
                             {item.garantia}
                           </p>
-                        )}
+                        )} */}
                       </div>
                     </td>
                     <td className="py-4 text-right align-top">
@@ -201,7 +202,14 @@ export const OrdenPreview = ({
                   </span>
                 </div>
               )}
-              <div className="flex justify-between">
+              {orden.credito > 0 && (
+                <div className="flex justify-between text-red-600">
+                  <span>Crédito aplicado:</span>
+                  <span>-{currencyFormat({ value: orden.credito })}</span>
+                </div>
+              )}
+              {/* Ocultando la fila de impuesto en la sección de totales, pero dejando el código comentado para referencia futura */}
+              {/* <div className="flex justify-between">
                 <span>Impuesto ({orden.impuesto}%):</span>
                 <span className="font-medium">
                   {currencyFormat({
@@ -214,13 +222,7 @@ export const OrdenPreview = ({
                       100,
                   })}
                 </span>
-              </div>
-              {orden.credito > 0 && (
-                <div className="flex justify-between text-red-600">
-                  <span>Crédito aplicado:</span>
-                  <span>-{currencyFormat({ value: orden.credito })}</span>
-                </div>
-              )}
+              </div> */}
               <div className="flex justify-between pt-3">
                 <span className="font-bold">Total:</span>
                 <span className="font-bold">

--- a/packages/panel/src/pages/ordenes/OrdenesPage.tsx
+++ b/packages/panel/src/pages/ordenes/OrdenesPage.tsx
@@ -216,12 +216,21 @@ const OrdenesPage: React.FC = () => {
           hideFilter
         />
       )}
-      <div className="fixed bottom-4 left-4 z-50 group">
-        <div className="w-[300px] h-[200px] transition-all duration-300 ease-in-out transform translate-y-[180px] group-hover:translate-y-0">
+      {/* Widget de cotización flotante, solo visible una franja de 35px pegada al borde inferior. Al hacer hover se expande. */}
+      <div className="fixed bottom-0 left-4 z-50" style={{ width: 300 }}>
+        <div
+          className="group w-full transition-all duration-300 ease-in-out overflow-hidden rounded-t-lg shadow border border-gray-200 bg-white"
+          style={{ height: "35px" }} // Altura inicial visible
+          // Al hacer hover, expande el widget; al salir, lo colapsa
+          onMouseEnter={(e) => (e.currentTarget.style.height = "263px")}
+          onMouseLeave={(e) => (e.currentTarget.style.height = "35px")}
+        >
+          {/* Iframe de elcamb.io, siempre ocupa 263px pero solo se muestra completo al expandirse */}
           <iframe
             src="https://elcamb.io/?embed=true"
-            className="w-full h-full rounded-lg border-0"
+            className="w-full h-[263px] rounded-lg border-0"
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            style={{ pointerEvents: "auto" }}
           />
         </div>
       </div>

--- a/packages/panel/src/pages/ordenes/OrdenesPage.tsx
+++ b/packages/panel/src/pages/ordenes/OrdenesPage.tsx
@@ -180,11 +180,21 @@ const OrdenesPage: React.FC = () => {
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="Todos">Todos</SelectItem>
-                {Object.values(EstatusOrden).map((c) => (
-                  <SelectItem key={c} value={c}>
-                    {c}
-                  </SelectItem>
-                ))}
+                {/* Solo se muestran los estatus que NO son Pendiente, Procesando ni Cerrado */}
+                {Object.values(EstatusOrden)
+                  .filter(
+                    (c) =>
+                      ![
+                        EstatusOrden.pendiente,
+                        EstatusOrden.procesando,
+                        EstatusOrden.cerrado,
+                      ].includes(c)
+                  )
+                  .map((c) => (
+                    <SelectItem key={c} value={c}>
+                      {c}
+                    </SelectItem>
+                  ))}
               </SelectContent>
             </Select>
           </div>

--- a/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
+++ b/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
@@ -202,11 +202,20 @@ export const columnasOrdenes: ColumnDef<Orden>[] = [
           </SelectTrigger>
           {/*
             Si el tipo de orden es cotización, solo permitir seleccionar los estatus 'Aprobado' y 'Rechazado'.
+            Si el tipo de orden es reposición, solo permitir seleccionar los estatus 'Aprobado', 'Confirmado', 'Enviado', 'Recibido' y 'Cancelado'.
             Para otros tipos de orden, mostrar todos los estatus posibles.
           */}
           <SelectContent>
             {(orden.tipo === TipoOrden.cotizacion
               ? [EstatusOrden.aprobado, EstatusOrden.rechazado]
+              : orden.tipo === TipoOrden.reposicion
+              ? [
+                  EstatusOrden.aprobado, // Solo para reposición
+                  EstatusOrden.confirmado, // Solo para reposición
+                  EstatusOrden.enviado, // Solo para reposición
+                  EstatusOrden.recibido, // Solo para reposición
+                  EstatusOrden.cancelado, // Solo para reposición
+                ]
               : Object.values(EstatusOrden)
             ).map((est) => (
               <SelectItem

--- a/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
+++ b/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
@@ -200,8 +200,15 @@ export const columnasOrdenes: ColumnDef<Orden>[] = [
           <SelectTrigger className={`${getEstatusColor(orden.estatus)}`}>
             <SelectValue>{orden.estatus || EstatusOrden.pendiente}</SelectValue>
           </SelectTrigger>
+          {/*
+            Si el tipo de orden es cotización, solo permitir seleccionar los estatus 'Aprobado' y 'Rechazado'.
+            Para otros tipos de orden, mostrar todos los estatus posibles.
+          */}
           <SelectContent>
-            {Object.values(EstatusOrden).map((est) => (
+            {(orden.tipo === TipoOrden.cotizacion
+              ? [EstatusOrden.aprobado, EstatusOrden.rechazado]
+              : Object.values(EstatusOrden)
+            ).map((est) => (
               <SelectItem
                 key={est}
                 value={est}

--- a/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
+++ b/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
@@ -245,7 +245,28 @@ export const columnasOrdenes: ColumnDef<Orden>[] = [
                   (estatusOrden[est] === 0 && estatusActualNivel > 2) ||
                   // Deshabilitar estados anteriores
                   (estatusOrden[est] !== 0 &&
-                    estatusOrden[est] < estatusActualNivel)
+                    estatusOrden[est] < estatusActualNivel) ||
+                  // --- Reglas especiales para venta y crédito ---
+                  // Si el estatus actual es aprobado, deshabilitar entregado
+                  ((orden.tipo === TipoOrden.venta ||
+                    orden.tipo === TipoOrden.credito) &&
+                    orden.estatus === EstatusOrden.aprobado &&
+                    est === EstatusOrden.entregado) ||
+                  // Si el estatus actual es rechazado, deshabilitar confirmado, entregado y cancelado
+                  ((orden.tipo === TipoOrden.venta ||
+                    orden.tipo === TipoOrden.credito) &&
+                    orden.estatus === EstatusOrden.rechazado &&
+                    (est === EstatusOrden.confirmado ||
+                      est === EstatusOrden.entregado ||
+                      est === EstatusOrden.cancelado)) ||
+                  // Si el estatus actual es cancelado, deshabilitar rechazado, confirmado y entregado
+                  ((orden.tipo === TipoOrden.venta ||
+                    orden.tipo === TipoOrden.credito) &&
+                    orden.estatus === EstatusOrden.cancelado &&
+                    (est === EstatusOrden.rechazado ||
+                      est === EstatusOrden.confirmado ||
+                      est === EstatusOrden.entregado))
+                  // --- Fin reglas especiales ---
                 }
               >
                 {est}

--- a/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
+++ b/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
@@ -516,8 +516,12 @@ export const columnasOrdenes: ColumnDef<Orden>[] = [
                 </AlertDialogContent>
               </AlertDialog>
             ) : null}
-
-            {orden.tipo === TipoOrden.cotizacion ? (
+            {/* 
+            Solo mostrar la opción de convertir en orden si la cotización NO está rechazada
+            Esto previene que cotizaciones rechazadas puedan ser convertidas desde el frontend
+            */}
+            {orden.tipo === TipoOrden.cotizacion &&
+            orden.estatus !== EstatusOrden.rechazado ? (
               <AlertDialog open={openConvertir}>
                 <Button
                   variant="secondary"

--- a/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
+++ b/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
@@ -265,7 +265,19 @@ export const columnasOrdenes: ColumnDef<Orden>[] = [
                     orden.estatus === EstatusOrden.cancelado &&
                     (est === EstatusOrden.rechazado ||
                       est === EstatusOrden.confirmado ||
-                      est === EstatusOrden.entregado))
+                      est === EstatusOrden.entregado)) ||
+                  // --- Reglas especiales para reposición ---
+                  // Si el estatus actual es aprobado, deshabilitar enviado y recibido
+                  (orden.tipo === TipoOrden.reposicion &&
+                    orden.estatus === EstatusOrden.aprobado &&
+                    (est === EstatusOrden.enviado ||
+                      est === EstatusOrden.recibido)) ||
+                  // Si el estatus actual es cancelado, deshabilitar confirmado, enviado y recibido
+                  (orden.tipo === TipoOrden.reposicion &&
+                    orden.estatus === EstatusOrden.cancelado &&
+                    (est === EstatusOrden.confirmado ||
+                      est === EstatusOrden.enviado ||
+                      est === EstatusOrden.recibido))
                   // --- Fin reglas especiales ---
                 }
               >

--- a/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
+++ b/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
@@ -203,9 +203,16 @@ export const columnasOrdenes: ColumnDef<Orden>[] = [
           {/*
             Si el tipo de orden es cotización, solo permitir seleccionar los estatus 'Aprobado' y 'Rechazado'.
             Si el tipo de orden es reposición, solo permitir seleccionar los estatus 'Aprobado', 'Confirmado', 'Enviado', 'Recibido' y 'Cancelado'.
+            Si el tipo de orden es Venta o Crédito, solo permitir seleccionar los estatus 'Aprobado', 'Rechazado', 'Confirmado', 'Entregado' y 'Cancelado'.
             Para otros tipos de orden, mostrar todos los estatus posibles.
           */}
           <SelectContent>
+            {/*
+              Si el tipo de orden es cotización, solo permitir seleccionar los estatus 'Aprobado' y 'Rechazado'.
+              Si el tipo de orden es reposición, solo permitir seleccionar los estatus 'Aprobado', 'Confirmado', 'Enviado', 'Recibido' y 'Cancelado'.
+              Si el tipo de orden es Venta o Crédito, solo permitir seleccionar los estatus 'Aprobado', 'Rechazado', 'Confirmado', 'Entregado' y 'Cancelado'.
+              Para otros tipos de orden, mostrar todos los estatus posibles.
+            */}
             {(orden.tipo === TipoOrden.cotizacion
               ? [EstatusOrden.aprobado, EstatusOrden.rechazado]
               : orden.tipo === TipoOrden.reposicion
@@ -215,6 +222,15 @@ export const columnasOrdenes: ColumnDef<Orden>[] = [
                   EstatusOrden.enviado, // Solo para reposición
                   EstatusOrden.recibido, // Solo para reposición
                   EstatusOrden.cancelado, // Solo para reposición
+                ]
+              : orden.tipo === TipoOrden.venta ||
+                orden.tipo === TipoOrden.credito
+              ? [
+                  EstatusOrden.aprobado, // Solo para Venta y Crédito
+                  EstatusOrden.rechazado, // Solo para Venta y Crédito
+                  EstatusOrden.confirmado, // Solo para Venta y Crédito
+                  EstatusOrden.entregado, // Solo para Venta y Crédito
+                  EstatusOrden.cancelado, // Solo para Venta y Crédito
                 ]
               : Object.values(EstatusOrden)
             ).map((est) => (

--- a/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
+++ b/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
@@ -525,11 +525,16 @@ export const columnasOrdenes: ColumnDef<Orden>[] = [
               <AlertDialog open={openConvertir}>
                 <Button
                   variant="secondary"
-                  className="text-xs gap-2 hover:text-green-500"
+                  className="text-xs gap-1 hover:text-green-500 whitespace-pre-line text-center min-w-[110px] pr-2"
                   onClick={() => setOpenConvertir(true)}
                 >
-                  <CheckCircleIcon size={16} className="text-green-500" />{" "}
-                  Convertir en orden
+                  {/* Icono de verificación alineado a la izquierda del texto */}
+                  <CheckCircleIcon
+                    size={16}
+                    className="text-green-500 mr-0.5 -ml-2"
+                  />{" "}
+                  {/* Texto en dos líneas para evitar scroll horizontal innecesario */}
+                  {`Convertir en\nOrden`}
                 </Button>
                 <AlertDialogContent>
                   <AlertDialogHeader>

--- a/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
+++ b/packages/panel/src/pages/ordenes/columnas.ordenes.tsx
@@ -185,8 +185,10 @@ export const columnasOrdenes: ColumnDef<Orden>[] = [
       const estatusActualNivel = estatusOrden[orden.estatus];
 
       return canCreate ? (
+        // Usar 'value' en vez de 'defaultValue' para que el Select siempre refleje el estatus actual de la orden,
+        // incluso si cambia dinámicamente por sockets u otras actualizaciones externas.
         <Select
-          defaultValue={orden.estatus || EstatusOrden.pendiente}
+          value={orden.estatus || EstatusOrden.pendiente}
           onValueChange={(value) => {
             actualizarEstatusOrden(
               (row.original as IOrden).id,

--- a/packages/panel/src/pages/productos/ProductoStockModal.tsx
+++ b/packages/panel/src/pages/productos/ProductoStockModal.tsx
@@ -72,10 +72,16 @@ export default function ProductoStockModal({
     }
   );
 
-  // Load stock when almacén changes
+  // Estado local para mostrar un spinner mientras se carga el stock del almacén seleccionado
+  const [loadingStock, setLoadingStock] = useState(false);
+
+  // Cuando cambia el almacén seleccionado, se solicita el stock y se muestra un spinner hasta que termina
   useEffect(() => {
     if (selectedAlmacen && producto) {
-      getStock(producto.id, selectedAlmacen);
+      setLoadingStock(true);
+      getStock(producto.id, selectedAlmacen).finally(() =>
+        setLoadingStock(false)
+      );
     }
   }, [selectedAlmacen, producto, getStock]);
 
@@ -160,63 +166,76 @@ export default function ProductoStockModal({
                 </Select>
               </div>
 
-              {selectedAlmacen && (
-                <>
-                  <div className="space-y-2">
-                    <Label>Actual</Label>
-                    <Input
-                      type="number"
-                      value={currentStock.actual?.toString() || "0"}
-                      onChange={(e) =>
-                        setCurrentStock({
-                          ...currentStock,
-                          actual: parseInt(e.target.value) || 0,
-                        })
-                      }
-                    />
+              {selectedAlmacen &&
+                // Si loadingStock es true, se muestra un spinner en vez de los inputs de stock
+                (loadingStock ? (
+                  <div className="flex justify-center items-center py-8">
+                    <Spinner />
                   </div>
-                  <div className="space-y-2">
-                    <Label>Reservado</Label>
-                    <Input
-                      type="number"
-                      value={currentStock.reservado?.toString() || "0"}
-                      onChange={(e) =>
-                        setCurrentStock({
-                          ...currentStock,
-                          reservado: parseInt(e.target.value) || 0,
-                        })
-                      }
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label>En Tránsito</Label>
-                    <Input
-                      type="number"
-                      value={currentStock.transito?.toString() || "0"}
-                      onChange={(e) =>
-                        setCurrentStock({
-                          ...currentStock,
-                          transito: parseInt(e.target.value) || 0,
-                        })
-                      }
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <Label>RMA</Label>
-                    <Input
-                      type="number"
-                      value={currentStock.rma?.toString() || "0"}
-                      onChange={(e) =>
-                        setCurrentStock({
-                          ...currentStock,
-                          rma: parseInt(e.target.value) || 0,
-                        })
-                      }
-                    />
-                  </div>
-                  <Button onClick={handleStockSubmit}>Actualizar Stock</Button>
-                </>
-              )}
+                ) : (
+                  // Si loadingStock es false, se muestran los inputs para modificar el stock
+                  <>
+                    {/* Input para stock actual */}
+                    <div className="space-y-2">
+                      <Label>Actual</Label>
+                      <Input
+                        type="number"
+                        value={currentStock.actual?.toString() || "0"}
+                        onChange={(e) =>
+                          setCurrentStock({
+                            ...currentStock,
+                            actual: parseInt(e.target.value) || 0,
+                          })
+                        }
+                      />
+                    </div>
+                    {/* Input para stock reservado */}
+                    <div className="space-y-2">
+                      <Label>Reservado</Label>
+                      <Input
+                        type="number"
+                        value={currentStock.reservado?.toString() || "0"}
+                        onChange={(e) =>
+                          setCurrentStock({
+                            ...currentStock,
+                            reservado: parseInt(e.target.value) || 0,
+                          })
+                        }
+                      />
+                    </div>
+                    {/* Input para stock en tránsito */}
+                    <div className="space-y-2">
+                      <Label>En Tránsito</Label>
+                      <Input
+                        type="number"
+                        value={currentStock.transito?.toString() || "0"}
+                        onChange={(e) =>
+                          setCurrentStock({
+                            ...currentStock,
+                            transito: parseInt(e.target.value) || 0,
+                          })
+                        }
+                      />
+                    </div>
+                    {/* Input para stock RMA */}
+                    <div className="space-y-2">
+                      <Label>RMA</Label>
+                      <Input
+                        type="number"
+                        value={currentStock.rma?.toString() || "0"}
+                        onChange={(e) =>
+                          setCurrentStock({
+                            ...currentStock,
+                            rma: parseInt(e.target.value) || 0,
+                          })
+                        }
+                      />
+                    </div>
+                    <Button onClick={handleStockSubmit}>
+                      Actualizar Stock
+                    </Button>
+                  </>
+                ))}
             </div>
           )}
         </div>

--- a/packages/panel/src/pages/productos/ProductosPage.tsx
+++ b/packages/panel/src/pages/productos/ProductosPage.tsx
@@ -74,9 +74,11 @@ const ProductosPage: React.FC = () => {
   }, [categorias, listarCategorias]);
 
   // listar productos
+  // Forzamos la recarga del stock más reciente al montar la página de productos.
   useEffect(() => {
     listarProductos();
-  }, [listarProductos]);
+    // eslint-disable-next-line
+  }, []); // Forzar recarga solo al montar la página
 
   return (
     <div className="space-y-4">

--- a/packages/panel/src/pages/productos/columnas.productos.tsx
+++ b/packages/panel/src/pages/productos/columnas.productos.tsx
@@ -58,7 +58,8 @@ export const columnasProductos: ColumnDef<Producto>[] = [
   },
   {
     id: "stock",
-    header: "Stock",
+    // El título 'Stock' se alinea a la derecha para mejor visualización
+    header: () => <div className="text-right pr-20">Stock</div>,
     cell: ({ row }) => {
       const producto = row.original as IProducto;
       const { listarAlmacenesPorProducto } = useAlmacenesStore();
@@ -115,7 +116,8 @@ export const columnasProductos: ColumnDef<Producto>[] = [
   },
   {
     id: "costo",
-    header: "Costo",
+    // El título 'Costo' se alinea a la derecha para mejor visualización
+    header: () => <div className="text-right pr-1">Costo</div>,
     accessorFn: (row) => currencyFormat({ value: row.costo }),
     cell: ({ getValue }: CellContext<Producto, unknown>) => (
       <div className="text-right">
@@ -125,7 +127,8 @@ export const columnasProductos: ColumnDef<Producto>[] = [
   },
   {
     id: "precio",
-    header: "Precio",
+    // El título 'Precio' se alinea a la derecha para mejor visualización
+    header: () => <div className="text-right pr-2">Precio</div>,
     cell: ({ row }) => {
       // Se muestra el precioInstalador como precio principal
       // El precio tachado en caso de oferta es precioGeneral
@@ -172,7 +175,8 @@ export const columnasProductos: ColumnDef<Producto>[] = [
   },
   {
     id: "acciones",
-    header: "Acciones",
+    // El título 'Acciones' se alinea a la derecha para mejor visualización
+    header: () => <div className="text-right pr-24">Acciones</div>,
     cell: ({ row }) => {
       const producto = row.original as IProducto;
       const { user } = useAuthStore();

--- a/packages/panel/src/pages/productos/columnas.productos.tsx
+++ b/packages/panel/src/pages/productos/columnas.productos.tsx
@@ -127,8 +127,16 @@ export const columnasProductos: ColumnDef<Producto>[] = [
     id: "precio",
     header: "Precio",
     cell: ({ row }) => {
-      const { precioGeneral, precioOferta, enOferta, inicioOferta, finOferta } =
-        row.original;
+      // Se muestra el precioInstalador como precio principal
+      // El precio tachado en caso de oferta es precioGeneral
+      const {
+        precioGeneral,
+        precioInstalador,
+        precioOferta,
+        enOferta,
+        inicioOferta,
+        finOferta,
+      } = row.original;
       const now = new Date();
       const isOfferActive =
         enOferta &&
@@ -140,9 +148,11 @@ export const columnasProductos: ColumnDef<Producto>[] = [
       if (isOfferActive) {
         return (
           <div className="flex flex-col items-end">
+            {/* Precio general tachado cuando hay oferta */}
             <span className="text-sm line-through text-muted-foreground">
               {currencyFormat({ value: precioGeneral })}
             </span>
+            {/* Precio de oferta */}
             <span className="text-sm font-semibold text-primary">
               {currencyFormat({ value: precioOferta })}
             </span>
@@ -150,10 +160,11 @@ export const columnasProductos: ColumnDef<Producto>[] = [
         );
       }
 
+      // Precio de instalador cuando no hay oferta
       return (
         <div className="text-right">
           <span className="text-sm">
-            {currencyFormat({ value: precioGeneral })}
+            {currencyFormat({ value: precioInstalador })}
           </span>
         </div>
       );

--- a/packages/panel/src/store/transacciones.store.ts
+++ b/packages/panel/src/store/transacciones.store.ts
@@ -30,6 +30,7 @@ export type TransaccionesStore = {
   balance: number;
   setBalance: (balance: number) => void;
   isLoading: boolean;
+  reset: () => void; // Método para limpiar el estado del store y dejarlo en su estado inicial
 };
 
 const initialState: Pick<
@@ -102,6 +103,7 @@ export const useTransaccionesStore = create<TransaccionesStore>()(
       },
       setLimit: (limit) => set({ limit }),
       setBalance: (balance) => set({ balance }),
+      reset: () => set({ ...initialState }), // Limpia el estado del store de transacciones al estado inicial
     }),
     {
       name: "transacciones-store",

--- a/packages/shared/src/interfaces.ts
+++ b/packages/shared/src/interfaces.ts
@@ -211,6 +211,10 @@ export interface IItemOrden extends IBase {
   notas: string;
   almacen: IAlmacen | null;
   garantia: string;
+  /** Nuevo: Indica si el precio fue editado manualmente por el usuario.
+   * Si es true, el precio no se sobrescribe automáticamente al cambiar el tipo de cambio u otros factores.
+   */
+  precioManual?: boolean;
 }
 
 export interface IOrden extends IBase {


### PR DESCRIPTION
Actualiza los precios de los productos segun el tipo de cambio de BCV a USD o viceversa de forma dinamica, una vez que ya se haya empezado con la orden. Tambien se puede cambiar el precio de forma manual, se implemento una lógica especifica y adicional un boton que al detectarse un cambio manual del precio, aparecera permitiendo deshacer el cambio del precio ingresado, asignando el original según el tipo de cambio seleccionado.
Hubo cambios adicionales referentes a la exportacion de componentes en el archivo button.tsx y se corrigieron las dependencias correspondientes.