### PR TITLE
Creacion de PDF - Factura Proforma

### DIFF
--- a/packages/backend/src/providers/pdf/pdf.ts
+++ b/packages/backend/src/providers/pdf/pdf.ts
@@ -288,7 +288,7 @@ export class PDFProvider {
     const totalToPay = subtotal + ivaAmount;
 
     // Sección de totales abajo a la derecha
-    const totalsX = width - 197;
+    const totalsX = width - 181;
     let totalsY = 60;
 
     // Sub-total
@@ -305,7 +305,7 @@ export class PDFProvider {
     });
     const subtotalWidth = helveticaFont.widthOfTextAtSize(subtotalText, 10);
     page.drawText(subtotalText, {
-      x: totalsX + 150 - subtotalWidth,
+      x: totalsX + 140 - subtotalWidth,
       y: totalsY,
       size: 10,
       font: helveticaFont,
@@ -327,7 +327,7 @@ export class PDFProvider {
     });
     const ivaWidth = helveticaFont.widthOfTextAtSize(ivaText, 10);
     page.drawText(ivaText, {
-      x: totalsX + 150 - ivaWidth,
+      x: totalsX + 140 - ivaWidth,
       y: totalsY,
       size: 10,
       font: helveticaFont,
@@ -349,7 +349,7 @@ export class PDFProvider {
     });
     const totalWidth = helveticaFont.widthOfTextAtSize(totalText, 10);
     page.drawText(totalText, {
-      x: totalsX + 150 - totalWidth,
+      x: totalsX + 140 - totalWidth,
       y: totalsY,
       size: 10,
       font: helveticaFont,
@@ -1274,6 +1274,21 @@ export class PDFProvider {
             font: helveticaBold,
             color: primaryColor,
           });
+        } else if (columnTitles[i] === "Descripción") {
+          // Centrar "Descripción"
+          const descripcionWidth = helveticaBold.widthOfTextAtSize(
+            columnTitles[i],
+            9
+          );
+          const descripcionX =
+            currentX + columnWidths[i] / 2 - descripcionWidth / 2;
+          page.drawText(columnTitles[i], {
+            x: descripcionX,
+            y: yPosition,
+            size: 9,
+            font: helveticaBold,
+            color: primaryColor,
+          });
         } else {
           page.drawText(columnTitles[i], {
             x: currentX,
@@ -1355,6 +1370,21 @@ export class PDFProvider {
                 font: helveticaBold,
                 color: primaryColor,
               });
+            } else if (columnTitles[i] === "Descripción") {
+              // Centrar "Descripción"
+              const descripcionWidth = helveticaBold.widthOfTextAtSize(
+                columnTitles[i],
+                9
+              );
+              const descripcionX =
+                currentX + columnWidths[i] / 2 - descripcionWidth / 2;
+              page.drawText(columnTitles[i], {
+                x: descripcionX,
+                y: yPosition,
+                size: 9,
+                font: helveticaBold,
+                color: primaryColor,
+              });
             } else {
               page.drawText(columnTitles[i], {
                 x: currentX,
@@ -1423,14 +1453,8 @@ export class PDFProvider {
           maximumFractionDigits: 2,
         });
         const totalWidth = helveticaFont.widthOfTextAtSize(totalText, 9);
-        const totalHeaderText = "Total";
-        const totalHeaderWidth = helveticaBold.widthOfTextAtSize(
-          totalHeaderText,
-          9
-        );
-        const totalHeaderCenter = currentX + totalHeaderWidth / 2;
         page.drawText(totalText, {
-          x: totalHeaderCenter - totalWidth / 2,
+          x: currentX + columnWidths[3] - totalWidth - 90,
           y: yPosition,
           size: 9,
           font: helveticaFont,

--- a/packages/backend/src/providers/pdf/pdf.ts
+++ b/packages/backend/src/providers/pdf/pdf.ts
@@ -662,7 +662,7 @@ export class PDFProvider {
         columnWidths
       );
 
-      yPosition -= 35; // Account for headers and separator line
+      yPosition -= 35;
 
       // Items
       for (let index = 0; index < orden.items.length; index++) {
@@ -1060,6 +1060,320 @@ export class PDFProvider {
         throw error;
       }
       throw new Error("Failed to generate order PDF");
+    }
+  }
+
+  public async generateProformaPDF(orden: IOrden): Promise<Buffer> {
+    try {
+      console.log("Starting proforma PDF generation for order:", orden.serial);
+
+      // Create a new PDF document with half letter height
+      const pdfDoc = await PDFDocument.create();
+      const pageWidth = 612; // Full letter width
+      const pageHeight = 792 / 2; // Half of letter height
+      let page = pdfDoc.addPage([pageWidth, pageHeight]);
+      const { width, height } = page.getSize();
+
+      // Load fonts
+      const helveticaFont = await pdfDoc.embedFont(StandardFonts.Helvetica);
+      const helveticaBold = await pdfDoc.embedFont(StandardFonts.HelveticaBold);
+
+      // Colors
+      const primaryColor = rgb(0.2, 0.2, 0.2);
+      const secondaryColor = rgb(0.4, 0.4, 0.4);
+
+      // Constants
+      const ivaActual = 0.16; // 16% IVA
+      const leftMargin = 40;
+      const maxItemsPerPage = 11;
+
+      // --- HEADER ---
+      await this.drawHeader(
+        page,
+        pdfDoc,
+        helveticaFont,
+        helveticaBold,
+        primaryColor
+      );
+      // --- END HEADER ---
+
+      // Iniciar la tabla justo debajo del header
+      let yPosition = height - 120;
+
+      // Tabla de productos
+      const columnWidths = [60, 340, 100, 120]; // Cantidad, Descripción, Precio Unitario, Total
+      const columnTitles = [
+        "Cantidad",
+        "Descripción",
+        "Precio Unitario",
+        "Total",
+      ];
+
+      // Dibujar encabezados de la tabla
+      let currentX = leftMargin;
+      for (let i = 0; i < columnTitles.length; i++) {
+        if (columnTitles[i] === "Precio Unitario") {
+          // Centrar "Precio" y "Unitario" en la columna
+          const precioText = "Precio";
+          const unitarioText = "Unitario";
+          const precioWidth = helveticaBold.widthOfTextAtSize(precioText, 9);
+          const unitarioWidth = helveticaBold.widthOfTextAtSize(
+            unitarioText,
+            9
+          );
+          const precioX = currentX + columnWidths[i] / 2 - precioWidth / 2;
+          const unitarioX = currentX + columnWidths[i] / 2 - unitarioWidth / 2;
+          page.drawText(precioText, {
+            x: precioX,
+            y: yPosition,
+            size: 9,
+            font: helveticaBold,
+            color: primaryColor,
+          });
+          page.drawText(unitarioText, {
+            x: unitarioX,
+            y: yPosition - 11,
+            size: 9,
+            font: helveticaBold,
+            color: primaryColor,
+          });
+        } else {
+          page.drawText(columnTitles[i], {
+            x: currentX,
+            y: yPosition,
+            size: 9,
+            font: helveticaBold,
+            color: primaryColor,
+          });
+        }
+        currentX += columnWidths[i];
+      }
+      yPosition -= 24;
+
+      // Items
+      let pageItemCount = 0;
+      for (let index = 0; index < orden.items.length; index++) {
+        const item = orden.items[index];
+        // Nueva página si se excede el máximo
+        if (pageItemCount >= maxItemsPerPage) {
+          page = pdfDoc.addPage([pageWidth, pageHeight]);
+          await this.drawHeader(
+            page,
+            pdfDoc,
+            helveticaFont,
+            helveticaBold,
+            primaryColor
+          );
+          yPosition = height - 120;
+          pageItemCount = 0;
+          // Redibujar encabezados
+          currentX = leftMargin;
+          for (let i = 0; i < columnTitles.length; i++) {
+            if (columnTitles[i] === "Precio Unitario") {
+              const precioText = "Precio";
+              const unitarioText = "Unitario";
+              const precioWidth = helveticaBold.widthOfTextAtSize(
+                precioText,
+                9
+              );
+              const unitarioWidth = helveticaBold.widthOfTextAtSize(
+                unitarioText,
+                9
+              );
+              const precioX = currentX + columnWidths[i] / 2 - precioWidth / 2;
+              const unitarioX =
+                currentX + columnWidths[i] / 2 - unitarioWidth / 2;
+              page.drawText(precioText, {
+                x: precioX,
+                y: yPosition,
+                size: 9,
+                font: helveticaBold,
+                color: primaryColor,
+              });
+              page.drawText(unitarioText, {
+                x: unitarioX,
+                y: yPosition - 11,
+                size: 9,
+                font: helveticaBold,
+                color: primaryColor,
+              });
+            } else {
+              page.drawText(columnTitles[i], {
+                x: currentX,
+                y: yPosition,
+                size: 9,
+                font: helveticaBold,
+                color: primaryColor,
+              });
+            }
+            currentX += columnWidths[i];
+          }
+          yPosition -= 24;
+        }
+        currentX = leftMargin;
+        // Cantidad
+        page.drawText(item.cantidad.toString(), {
+          x: currentX,
+          y: yPosition,
+          size: 9,
+          font: helveticaFont,
+          color: primaryColor,
+        });
+        currentX += columnWidths[0];
+        // Descripción
+        page.drawText(item.producto.nombre, {
+          x: currentX,
+          y: yPosition,
+          size: 9,
+          font: helveticaFont,
+          color: primaryColor,
+        });
+        currentX += columnWidths[1];
+        // Precio Unitario (precio * tasa de cambio BCV)
+        const unitPrice =
+          orden.tipoCambio === TipoCambio.bcv
+            ? item.precio * orden.tasaCambio
+            : item.precio;
+        const unitPriceText = unitPrice.toLocaleString("es-VE", {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        });
+        const unitPriceWidth = helveticaFont.widthOfTextAtSize(
+          unitPriceText,
+          9
+        );
+        page.drawText(unitPriceText, {
+          x: currentX + columnWidths[2] - unitPriceWidth - 31,
+          y: yPosition,
+          size: 9,
+          font: helveticaFont,
+          color: primaryColor,
+        });
+        currentX += columnWidths[2];
+        // Total (cantidad * precio unitario)
+        const totalPrice = item.cantidad * unitPrice;
+        const totalText = totalPrice.toLocaleString("es-VE", {
+          minimumFractionDigits: 2,
+          maximumFractionDigits: 2,
+        });
+        const totalWidth = helveticaFont.widthOfTextAtSize(totalText, 9);
+        page.drawText(totalText, {
+          x: currentX + 5,
+          y: yPosition,
+          size: 9,
+          font: helveticaFont,
+          color: primaryColor,
+        });
+        currentX += columnWidths[3];
+        yPosition -= 20;
+        pageItemCount++;
+      }
+
+      // Totales
+      const subtotal = orden.items.reduce((sum, item) => {
+        const unitPrice =
+          orden.tipoCambio === TipoCambio.bcv
+            ? item.precio * orden.tasaCambio
+            : item.precio;
+        return sum + item.cantidad * unitPrice;
+      }, 0);
+      const ivaAmount = subtotal * ivaActual;
+      const totalToPay = subtotal + ivaAmount;
+
+      // Sección de totales abajo a la derecha
+      const totalsX = width - 250;
+      let totalsY = 80;
+      // Sub-total
+      page.drawText("Sub-total:", {
+        x: totalsX,
+        y: totalsY,
+        size: 10,
+        font: helveticaBold,
+        color: primaryColor,
+      });
+      const subtotalText = currencyFormat({
+        value: subtotal,
+        currency: orden.tipoCambio === TipoCambio.bcv ? "VES" : "USD",
+        locale: orden.tipoCambio === TipoCambio.bcv ? "es-VE" : "en-US",
+      });
+      const subtotalWidth = helveticaFont.widthOfTextAtSize(subtotalText, 10);
+      page.drawText(subtotalText, {
+        x: totalsX + 150 - subtotalWidth,
+        y: totalsY,
+        size: 10,
+        font: helveticaFont,
+        color: primaryColor,
+      });
+      totalsY -= 20;
+      // IVA (16%)
+      page.drawText("IVA (16%):", {
+        x: totalsX,
+        y: totalsY,
+        size: 10,
+        font: helveticaBold,
+        color: primaryColor,
+      });
+      const ivaText = currencyFormat({
+        value: ivaAmount,
+        currency: orden.tipoCambio === TipoCambio.bcv ? "VES" : "USD",
+        locale: orden.tipoCambio === TipoCambio.bcv ? "es-VE" : "en-US",
+      });
+      const ivaWidth = helveticaFont.widthOfTextAtSize(ivaText, 10);
+      page.drawText(ivaText, {
+        x: totalsX + 150 - ivaWidth,
+        y: totalsY,
+        size: 10,
+        font: helveticaFont,
+        color: primaryColor,
+      });
+      totalsY -= 20;
+      // Total a Pagar
+      page.drawText("Total a Pagar:", {
+        x: totalsX,
+        y: totalsY,
+        size: 10,
+        font: helveticaBold,
+        color: primaryColor,
+      });
+      const totalText = currencyFormat({
+        value: totalToPay,
+        currency: orden.tipoCambio === TipoCambio.bcv ? "VES" : "USD",
+        locale: orden.tipoCambio === TipoCambio.bcv ? "es-VE" : "en-US",
+      });
+      const totalWidth = helveticaFont.widthOfTextAtSize(totalText, 10);
+      page.drawText(totalText, {
+        x: totalsX + 150 - totalWidth,
+        y: totalsY,
+        size: 10,
+        font: helveticaFont,
+        color: primaryColor,
+      });
+
+      // Mensaje de retención (izquierda, a la altura del Sub-total)
+      const retentionY = 80;
+      page.drawText(
+        "En caso de ser Agente de Retención, la Retención debe ser por el 100% del IVA",
+        {
+          x: leftMargin,
+          y: retentionY,
+          size: 9,
+          font: helveticaFont,
+          color: secondaryColor,
+        }
+      );
+
+      // Guardar PDF
+      console.log("Saving proforma PDF...");
+      const pdfBytes = await pdfDoc.save();
+      console.log("Proforma PDF saved successfully");
+
+      return Buffer.from(pdfBytes);
+    } catch (error) {
+      console.error("Proforma PDF generation error:", error);
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error("Failed to generate proforma PDF");
     }
   }
 }

--- a/packages/panel/src/pages/ordenes/OrdenPreview.tsx
+++ b/packages/panel/src/pages/ordenes/OrdenPreview.tsx
@@ -11,9 +11,9 @@ import {
   calcularTotalOrden,
   formatearFecha,
 } from "shared/helpers";
-import { TipoDescuento, TipoOrden } from "shared/enums";
-import { FileText, Download } from "lucide-react";
-import { useGeneratePDF } from "./ordenes.helpers";
+import { TipoDescuento, TipoOrden, TipoCambio } from "shared/enums";
+import { FileText, Download, Receipt } from "lucide-react";
+import { useGeneratePDF, useGenerateProformaPDF } from "./ordenes.helpers";
 
 interface OrdenPreviewProps {
   orden: IOrden;
@@ -27,6 +27,8 @@ export const OrdenPreview = ({
   onOpenChange,
 }: OrdenPreviewProps) => {
   const { generatePDF, isGeneratingPDF } = useGeneratePDF();
+  const { generateProformaPDF, isGeneratingProformaPDF } =
+    useGenerateProformaPDF();
 
   if (!orden) return null;
 
@@ -42,6 +44,10 @@ export const OrdenPreview = ({
     await generatePDF(orden);
   };
 
+  const handleGenerateProformaPDFWithOrden = async () => {
+    await generateProformaPDF(orden);
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-[850px] max-h-[90vh] overflow-y-auto p-0">
@@ -51,25 +57,48 @@ export const OrdenPreview = ({
           Fecha: {formatearFecha(orden.fechaCreado)}
         </DialogDescription>
 
-        {/* PDF Generation Button */}
+        {/* PDF Generation Buttons */}
         <div className="sticky top-0 z-10 bg-background border-b p-4">
-          <Button
-            onClick={handleGeneratePDFWithOrden}
-            disabled={isGeneratingPDF}
-            className="w-full sm:w-auto"
-          >
-            {isGeneratingPDF ? (
-              <>
-                <FileText className="mr-2 h-4 w-4 animate-spin" />
-                Generando PDF...
-              </>
-            ) : (
-              <>
-                <Download className="mr-2 h-4 w-4" />
-                Orden PDF
-              </>
+          <div className="relative flex items-center">
+            <Button
+              onClick={handleGeneratePDFWithOrden}
+              disabled={isGeneratingPDF}
+              className="w-full sm:w-auto"
+            >
+              {isGeneratingPDF ? (
+                <>
+                  <FileText className="mr-2 h-4 w-4 animate-spin" />
+                  Generando PDF...
+                </>
+              ) : (
+                <>
+                  <Download className="mr-2 h-4 w-4" />
+                  Orden PDF
+                </>
+              )}
+            </Button>
+            {orden.tipoCambio === TipoCambio.bcv && (
+              <div className="absolute left-1/2 transform -translate-x-1/2">
+                <Button
+                  onClick={handleGenerateProformaPDFWithOrden}
+                  disabled={isGeneratingProformaPDF}
+                  className="w-full sm:w-auto"
+                >
+                  {isGeneratingProformaPDF ? (
+                    <>
+                      <Receipt className="mr-2 h-4 w-4 animate-spin" />
+                      Generando Proforma...
+                    </>
+                  ) : (
+                    <>
+                      <Receipt className="mr-2 h-4 w-4" />
+                      Factura Proforma
+                    </>
+                  )}
+                </Button>
+              </div>
             )}
-          </Button>
+          </div>
         </div>
 
         {/* Scrollable container */}
@@ -106,7 +135,7 @@ export const OrdenPreview = ({
                     year: "numeric",
                   })}
                 </p>
-                {orden.tipoCambio === "BCV" && (
+                {orden.tipoCambio === TipoCambio.bcv && (
                   <p className="text-sm text-gray-500 mt-1">
                     Tasa BCV: {orden.tasaCambio}
                   </p>
@@ -284,7 +313,7 @@ export const OrdenPreview = ({
                   {currencyFormat({ value: totalConCredito })}
                 </span>
               </div>
-              {orden.tipoCambio === "BCV" && (
+              {orden.tipoCambio === TipoCambio.bcv && (
                 <div className="flex justify-between pt-1">
                   <span className="text-sm text-gray-500">Total en VES:</span>
                   <span className="text-sm text-gray-500">


### PR DESCRIPTION
Solo se muestra la opcion de Factura Proforma a Ordenes que tengan como tipo de cambio BCV.
Maximo 11 items por cada pagina.
Cada pagina generada calcula de forma individual el subtotal, iva y monto a pagar, esto es por que las facturas nuestras son de 11 items y cada una debe llevar su propio calculo.
muestra los mensajes para los agentes de retencion.
muestra la tasa de cambio bcv usada y la fecha.
No estoy seguro de si se deba confirmar al pedir hacer la proforma, el % de IVA y la tasa de cambio, creo que esto de debe hacer es con la orden Aprobada, una vez recibido el pago y hecha la factura, es que se debe confirmar la venta y luego proceder a entregar.