### PR TITLE
nueva regla para el calculo de las reposiciones del mes

### DIFF
--- a/packages/backend/src/routes/dashboard.routes.ts
+++ b/packages/backend/src/routes/dashboard.routes.ts
@@ -165,6 +165,14 @@ DashboardRouter.get("/charts", async (req: Request, res: Response) => {
       userId: user.id,
     })
     .andWhere("orden.tipo = :tipo", { tipo: TipoOrden.reposicion })
+    // Filtrar solo reposiciones con estatus Confirmado, Enviado o Recibido
+    .andWhere("orden.estatus IN (:...estatus)", {
+      estatus: [
+        EstatusOrden.confirmado,
+        EstatusOrden.enviado,
+        EstatusOrden.recibido,
+      ],
+    })
     .andWhere("orden.fechaCreado BETWEEN :start AND :end", {
       start: monthStart,
       end: monthEnd,


### PR DESCRIPTION
Mayor precisión en el valor real
Solo contar reposiciones que realmente están en proceso o completadas
Evitar incluir reposiciones canceladas o rechazadas que distorsionan el total
Reflejar mejor el valor real de las reposiciones activas
